### PR TITLE
Add virus scan error case to file API doc

### DIFF
--- a/references/V1_Files.yml
+++ b/references/V1_Files.yml
@@ -29,7 +29,7 @@ definitions:
         description: "The size of the file in bytes, uploads are capped at 20 megabytes."
       urls:
         type: string
-        description: "File access URLs (require Authorization token to invoke.)  metadata, link to file info.  noredirect_download, link to file contents in X-CONTENT-LOCATION header.  redirect_download, link to file contents via 302 redirect."
+        description: "File access URLs (require Authorization token to invoke.)  metadata, link to file info.  noredirect_download, link to file contents in X-CONTENT-LOCATION header.  redirect_download, link to file contents via 302 redirect.  If the file is flagged as potential malware, attempts to download the file will result in 404."
   Error:
     type: object
     description: "Response entity resulting from failed API call."


### PR DESCRIPTION
We will soon be enabling malware scanning of files by default.  The files service will begin returning a new error code when a file download is blocked due to a failing malware scan.