### PR TITLE
Added documentation for message-deleted webhook

### DIFF
--- a/guides/V1_wwsg_Webhooks.md
+++ b/guides/V1_wwsg_Webhooks.md
@@ -30,7 +30,7 @@ Available events are:
 
 **message-created**: each time a new message is created in the space
 
-**message-deleted**: each time a message is deleted from the space
+**message-deleted**: each time a message is deleted from the space. Please note that the **message-deleted** event API is currently `experimental` and subject to change. It is being included here to engage developers early with this API.
 
 **space-members-added**: each time a member is added to the space
 

--- a/guides/V1_wwsg_Webhooks.md
+++ b/guides/V1_wwsg_Webhooks.md
@@ -30,6 +30,8 @@ Available events are:
 
 **message-created**: each time a new message is created in the space
 
+**message-deleted**: each time a message is deleted from the space
+
 **space-members-added**: each time a member is added to the space
 
 **space-members-removed**: each time a member is removed from the space

--- a/guides/V1_wwsg_Webhooks.md
+++ b/guides/V1_wwsg_Webhooks.md
@@ -30,7 +30,7 @@ Available events are:
 
 **message-created**: each time a new message is created in the space
 
-**message-deleted**: each time a message is deleted from the space. Please note that the **message-deleted** event API is currently `experimental` and subject to change. It is being included here to engage developers early with this API.
+**message-deleted**: each time a message is deleted from the space. Please note that the **message-deleted** event API is currently `future` and subject to change. It is being included here to engage developers early with this API.
 
 **space-members-added**: each time a member is added to the space
 

--- a/references/V1_OutboundCallback.yml
+++ b/references/V1_OutboundCallback.yml
@@ -5,6 +5,8 @@ info:
   description: |
     This API has to be implemented by the callbacks implementing outbound webhooks.
 
+    - Changes in version 1.4.0:
+      - New event type and notification format for `message-deleted`
     - Changes in version 1.3.0:
       - Fields of input and output entities are correctly marked as required.
     - Changes in version 1.2.0:
@@ -25,6 +27,7 @@ definitions:
     allOf:
       - $ref: '#/definitions/VerificationInputBody'
       - $ref: '#/definitions/MessageCreatedBody'
+      - $ref: '#/definitions/MessageDeletedBody'
       - $ref: '#/definitions/SpaceMembersAddedBody'
       - $ref: '#/definitions/SpaceMembersRemovedBody'
       - $ref: '#/definitions/MessageAnnotationAddedBody'
@@ -102,6 +105,33 @@ definitions:
       - messageId
       - content
       - contentType
+      - time
+  MessageDeletedBody:
+    type: object
+    description: |
+      Notifies the deletion of a message from a space.
+
+      This event is only sent to webhooks that
+      - have been added for the message-deleted event
+      - and belong to an app that is a member of the space.
+    properties:
+      type:
+        description: The event type is `message-deleted`.
+        type: string
+      spaceId:
+        description: Id of the space in which the message was deleted.
+        type: string
+      messageId:
+        description: Unique id of the message.
+        type: string
+      time:
+        description: "Time and date of message deletion, in milliseconds since January 1st, 00:00, 1970 UTC"
+        type: integer
+        format: int64
+    required:
+      - type
+      - spaceId
+      - messageId
       - time
   SpaceMembersAddedBody:
     type: object

--- a/references/V1_OutboundCallback.yml
+++ b/references/V1_OutboundCallback.yml
@@ -6,7 +6,7 @@ info:
     This API has to be implemented by the callbacks implementing outbound webhooks.
 
     - Changes in version 1.4.0:
-      - New event type and notification format for `message-deleted`
+      - New event type and notification format for `message-deleted`.
     - Changes in version 1.3.0:
       - Fields of input and output entities are correctly marked as required.
     - Changes in version 1.2.0:

--- a/references/V1_OutboundCallback.yml
+++ b/references/V1_OutboundCallback.yml
@@ -93,7 +93,7 @@ definitions:
         description: Mime type of the message content.
         type: string
       time:
-        description: "Time and date of app creation, in milliseconds since January 1st, 00:00, 1970 UTC"
+        description: "Time and date of message creation, in milliseconds since January 1st, 00:00, 1970 UTC"
         type: integer
         format: int64
     required:
@@ -158,7 +158,7 @@ definitions:
           description: Id of a member that is added to the space.
           type: string
       time:
-        description: "Time and date of app creation, in milliseconds since January 1st, 00:00, 1970 UTC"
+        description: "Time and date of member addition, in milliseconds since January 1st, 00:00, 1970 UTC"
         type: integer
         format: int64
     required:
@@ -192,7 +192,7 @@ definitions:
           description: Id of a member that is removed from the space.
           type: string
       time:
-        description: "Time and date of app creation, in milliseconds since January 1st, 00:00, 1970 UTC"
+        description: "Time and date of member removal, in milliseconds since January 1st, 00:00, 1970 UTC"
         type: integer
         format: int64
     required:
@@ -234,7 +234,7 @@ definitions:
         description: Content of the annotation.  The format is JSON converted to a string.
         type: string
       time:
-        description: "Time and date of app creation, in milliseconds since January 1st, 00:00, 1970 UTC"
+        description: "Time and date of annotation added, in milliseconds since January 1st, 00:00, 1970 UTC"
         type: integer
         format: int64
     required:
@@ -281,7 +281,7 @@ definitions:
         description: Content of the edited annotation.  The format is JSON converted to a string.
         type: string
       time:
-        description: "Time and date of app creation, in milliseconds since January 1st, 00:00, 1970 UTC"
+        description: "Time and date of annotation edited, in milliseconds since January 1st, 00:00, 1970 UTC"
         type: integer
         format: int64
     required:
@@ -322,7 +322,7 @@ definitions:
         description: Id of the annotation that has been removed.
         type: string
       time:
-        description: Time and date of app creation, in milliseconds since January 1st, 00:00, 1970 UTC
+        description: Time and date of annotation removed, in milliseconds since January 1st, 00:00, 1970 UTC
         type: integer
         format: int64
     required:


### PR DESCRIPTION
# Changes include:

- Added `message-deleted` webhook documentation
- Edited `time` fields in other webhooks which I believed were incorrectly documented.
    - I took the liberty to address these in this PR but if you want I can separate this out.

Please feel free to suggest any changes, especially in the wording. Thanks!

@miguelestrada @jarusso 