### PR TITLE
Added documentation for deleteMessage mutation

### DIFF
--- a/guides/V1_delete_message.md
+++ b/guides/V1_delete_message.md
@@ -1,0 +1,48 @@
+---
+copyright: 'Copyright IBM Corp. 2017'
+link: 'delete-a-message'
+is: 'experimental'
+---
+
+# Delete a message
+
+## Concepts
+
+The _deleteMessage_ mutation allows the user to delete a message. Currently this is only applicable to messages which have been authored by the user. The mutation accepts a Message ID as an argument and makes the request on behalf of the calling user.
+
+## Schema
+
+### Delete Message Mutation
+
+
+
+```graphql
+type MutationRoot {
+  ...
+  deleteMessage(input: DeleteMessageInput!): DeleteOutput
+}
+
+type DeleteOutput {
+  successful: Boolean!
+}
+
+type DeleteMessageInput {
+  id: String!
+}
+```
+
+## Example Request
+
+~~~~
+Method: POST
+URL: https://api.watsonwork.ibm.com/graphql
+Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC, EXPERIMENTAL'
+Body:
+{
+  mutation {
+    deleteMessage(input: {id: "5a209f74e4b0faa757ac1afd"}) {
+      successful
+  }
+}
+~~~~
+

--- a/guides/V1_delete_message.md
+++ b/guides/V1_delete_message.md
@@ -1,7 +1,7 @@
 ---
 copyright: 'Copyright IBM Corp. 2017'
 link: 'delete-a-message'
-is: 'experimental'
+is: 'future'
 ---
 
 # Delete a message
@@ -45,4 +45,3 @@ Body:
   }
 }
 ~~~~
-


### PR DESCRIPTION
# Changes include:

- Added documentation for the `deleteMessage` mutation

Used the changes provided by @andrewegan in #22 as a base.

These APIs will also be available soon so wanted to start gathering feedback too.

@miguelestrada @jarusso - Would you mind reviewing this documentation? Thanks!