### PR TITLE
Added documentation for includeSoftDeleted param and softDeleted field

### DIFF
--- a/guides/V1_conversation_main.md
+++ b/guides/V1_conversation_main.md
@@ -17,4 +17,4 @@ Watson Work Services represents a Conversation with this object.
 | createdBy   | Person    | The person who created the space for this conversation |
 | updated     | Date    | The date that the space for this conversation  was updated at|
 | updatedBy   | Person | The person who updated the space for this conversation  |
-| messages(oldestTimestamp: Long, mostRecentTimestamp: Long, annotationType: String, before: String, after: String, first: Int, last: Int, includeSoftDeleted: Boolean) | MessageCollection | The messages of this conversation provided as a MessageCollection |
+| messages(oldestTimestamp: Long, mostRecentTimestamp: Long, annotationType: String, before: String, after: String, first: Int, last: Int, includeSoftDeleted: Boolean) | MessageCollection | The messages of this conversation provided as a MessageCollection. The `includeSoftDeleted` parameter requires the `EXPERIMENTAL` value in `x-graphql-view header`. |

--- a/guides/V1_conversation_main.md
+++ b/guides/V1_conversation_main.md
@@ -17,4 +17,4 @@ Watson Work Services represents a Conversation with this object.
 | createdBy   | Person    | The person who created the space for this conversation |
 | updated     | Date    | The date that the space for this conversation  was updated at|
 | updatedBy   | Person | The person who updated the space for this conversation  |
-| messages(oldestTimestamp: Long, mostRecentTimestamp: Long, annotationType: String, before: String, after: String, first: Int, last: Int) | MessageCollection | The messages of this conversation provided as a MessageCollection
+| messages(oldestTimestamp: Long, mostRecentTimestamp: Long, annotationType: String, before: String, after: String, first: Int, last: Int, includeSoftDeleted: Boolean) | MessageCollection | The messages of this conversation provided as a MessageCollection |

--- a/guides/V1_message_main.md
+++ b/guides/V1_message_main.md
@@ -18,7 +18,7 @@ Watson Work Services represents a Message with this object.
 | createdBy   | Person    | Person who created this message |
 | updated     | Date    | Date this message  was updated |
 | updatedBy   | Person | Person who updated this message  |
-| softDeleted | Boolean | Indicates whether this message is soft-deleted. Soft-deleted messages will return null content and empty annotations. |
+| softDeleted | Boolean | Indicates whether this message is soft-deleted. Soft-deleted messages will return null content and empty annotations. This requires the `EXPERIMENTAL` value in `x-graphql-view header`. |
 | content   | String | The body of the message |
 | contentType | String | Mime type of the message content  |
-| annotations | [String] | A set of optional objects/attachments that are added to a message, called annotations. Each annotation represents meta data that are related to the message. An annotation is represented by a structured format, which can be viewed as a template. There are different annotation types, some are used to store results of cognitive analysys to a message for example. An annotation can be added at message create time or later, as an update.  Apps are currently limited to create only one type of annotation called `generic` |
+| annotations | [String] | A set of optional objects/attachments that are added to a message, called annotations. Each annotation represents meta data that are related to the message. An annotation is represented by a structured format, which can be viewed as a template. There are different annotation types, some are used to store results of cognitive analysis to a message for example. An annotation can be added at message create time or later, as an update.  Apps are currently limited to create only one type of annotation called `generic` |

--- a/guides/V1_message_main.md
+++ b/guides/V1_message_main.md
@@ -18,6 +18,7 @@ Watson Work Services represents a Message with this object.
 | createdBy   | Person    | Person who created this message |
 | updated     | Date    | Date this message  was updated |
 | updatedBy   | Person | Person who updated this message  |
+| softDeleted | Boolean | Indicates whether this message is soft-deleted. Soft-deleted messages will return null content and empty annotations. |
 | content   | String | The body of the message |
 | contentType | String | Mime type of the message content  |
 | annotations | [String] | A set of optional objects/attachments that are added to a message, called annotations. Each annotation represents meta data that are related to the message. An annotation is represented by a structured format, which can be viewed as a template. There are different annotation types, some are used to store results of cognitive analysys to a message for example. An annotation can be added at message create time or later, as an update.  Apps are currently limited to create only one type of annotation called `generic` |


### PR DESCRIPTION
# Changes include:

- Added includeSoftDeleted parameter in the messages collection query
- Added softDeleted property to the message, along with documentation

@jarusso @miguelestrada - Would you mind reviewing these changes?

**This feature is currently enabled as `EXPERIMENTAL` but will be promoted to published in the feature enablement process. I just want to get ahead of this and gather feedback sooner rather than later.**

Thanks!