### PR TITLE
Moments

### DIFF
--- a/NavigationMenu.md
+++ b/NavigationMenu.md
@@ -8,7 +8,6 @@
   * [What's New](./Whats_New.md)
   * [Coming Next](./Coming_Next.md)
 
-
 * ## [Developer's Guide](./guides/V1_wwsg_DevelopersGuide.md)
   * [GraphQL API](./guides/V1_wwsg_GraphQLAPIIntro.md)
 
@@ -33,6 +32,8 @@
   * [Get my user information](./guides/V1_get_me.md)
   * [Update space membership](./guides/V1_update_space.md)
 
+* ## [Moment](./guides/V1_moment_main.md)
+  * [Get a list of moments in a space](./guides/V1_get_moments_in_conversation.md)
 
 * ## [Annotations](./guides/V1_annotations.md)
   * [Moments](./guides/V1_wwsg_MomentIdentification.md)

--- a/Whats_New.md
+++ b/Whats_New.md
@@ -1,5 +1,5 @@
 ---
-copyright: 'Copyright IBM Corp. 2017'
+copyright: 'Copyright IBM Corp. 2018'
 is: 'published'
 link: 'whats-new'
 ---
@@ -9,6 +9,7 @@ Keep up to date on what's new in IBM Watson Work Services. We'll list the latest
 
 | Date          | What's new       |
 | ------------- |:-------------|
+| 19.Jun.2018   | Added documentation section on [Moments GraphQL](./guides/V1_moment_main.md). |
 | 27.Mar.2018   | Added `space-updated` and `space-deleted` webhook events. |
 | 26.Mar.2018   | Updated [Focus](./guides/V1_wwsg_ActionIdentification.md), [Focus Annotation](guides/V2_Annotation_Message_Action_Identification.md), and [Focus API](./references/V1_Focus.yml) to reflect the classes produced by the latest implementation of Focus identification. After examining the usefulness of various categories for collaboration scenarios, a smaller set of categories with better precision is now used. See also [How AI can help enterprise workers automatically triage conversations](https://www.ibm.com/blogs/research/2018/01/ai-enterprise-workers-triage-convos/) for more information on the latest approach used for Focus identification. |
 | 27.Feb.2018   | Added guide for [Publish in the Catalog](./guides/V1_PublishInTheCatalog.md) and also the [App review checklist](./guides/V1_AppReviewChecklist.md). |

--- a/guides/V1_get_moments_in_conversation.md
+++ b/guides/V1_get_moments_in_conversation.md
@@ -12,11 +12,11 @@ is: 'beta'
 or with <a href="https://developer.watsonwork.ibm.com/tools/graphql?apiType=beta" target="_blank" >apiType=beta on the graphical GraphQL tool URL</a>.
 
 
-This is a sample GraphQL query to get moments in a space. Be sure to switch "space-id" to the id of the space you're curious about.
+This is a sample GraphQL query to get moments in a conversation. Be sure to switch "conversation-id" to the id of the conversation you're curious about.
 
 ```
 query getMomentsInConversation {
-  conversation(id: "space-id") {
+  conversation(id: "conversation-id") {
     moments {
       items {
         id
@@ -32,4 +32,4 @@ query getMomentsInConversation {
 }
 ```
 
-Try it out with our GraphQL tool - <a href="https://developer.watsonwork.ibm.com/tools/graphql?apiType=beta&query=query%20getMomentsInConversation%20%7B%0Aconversation(id%3A%20%22space-id%22)%20%7B%0Amoments%20%7B%0Aitems%20%7B%0Aid%0Alive%0AstartTime%0AendTime%0AsummaryPhrases(first%3A%203)%20%7B%0Alabel%0A%7D%0A%7D%0A%7D%0A%7D%0A%7D" target="_blank">Get a list of moments in conversation</a>
+Try it out with our GraphQL tool - <a href="https://developer.watsonwork.ibm.com/tools/graphql?apiType=beta&query=query%20getMomentsInConversation%20%7B%0Aconversation(id%3A%20%22conversation-id%22)%20%7B%0Amoments%20%7B%0Aitems%20%7B%0Aid%0Alive%0AstartTime%0AendTime%0AsummaryPhrases(first%3A%203)%20%7B%0Alabel%0A%7D%0A%7D%0A%7D%0A%7D%0A%7D" target="_blank">Get a list of moments in conversation</a>

--- a/guides/V1_get_moments_in_conversation.md
+++ b/guides/V1_get_moments_in_conversation.md
@@ -1,5 +1,5 @@
 ---
-copyright: 'Copyright IBM Corp. 2017'
+copyright: 'Copyright IBM Corp. 2018'
 link: 'get-a-list-of-moments-in-conversation'
 is: 'beta'
 ---
@@ -9,8 +9,10 @@ is: 'beta'
 
       x-graphql-view: BETA
 
+or with <a href="https://developer.watsonwork.ibm.com/tools/graphql?apiType=beta" target="_blank" >apiType=beta on the graphical GraphQL tool URL</a>.
 
-This is a sample GraphQL query to get moments in a space. Be sure to switch "space-id" to the actual id you're curious about.
+
+This is a sample GraphQL query to get moments in a space. Be sure to switch "space-id" to the id of the space you're curious about.
 
 ```
 query getMomentsInConversation {
@@ -21,11 +23,13 @@ query getMomentsInConversation {
         live
         startTime
         endTime
+        summaryPhrases(first: 3) {
+          label
+        }
       }
     }
   }
 }
-
 ```
 
-Try it out with our GraphQL tool - <a href="https://developer.watsonwork.ibm.com/tools/graphql?query=query%20getMomentsInConversation%20%7B%0A%20%20conversation(id%3A%20%22space-id%22)%20%7B%0A%20%20%20%20moments%20%7B%0A%20%20%20%20%20%20items%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20live%0A%20%20%20%20%20%20%20%20startTime%0A%20%20%20%20%20%20%20%20endTime%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&operationName=getMomentsInConversation" target="_blank">Get a list of moments in conversation</a>
+Try it out with our GraphQL tool - <a href="https://developer.watsonwork.ibm.com/tools/graphql?apiType=beta&query=query%20getMomentsInConversation%20%7B%0Aconversation(id%3A%20%22space-id%22)%20%7B%0Amoments%20%7B%0Aitems%20%7B%0Aid%0Alive%0AstartTime%0AendTime%0AsummaryPhrases(first%3A%203)%20%7B%0Alabel%0A%7D%0A%7D%0A%7D%0A%7D%0A%7D" target="_blank">Get a list of moments in conversation</a>

--- a/guides/V1_moment_main.md
+++ b/guides/V1_moment_main.md
@@ -1,5 +1,5 @@
 ---
-copyright: 'Copyright IBM Corp. 2017'
+copyright: 'Copyright IBM Corp. 2018'
 link: 'moment'
 is: 'beta'
 ---
@@ -9,93 +9,59 @@ is: 'beta'
 
       x-graphql-view: BETA
 
+or with <a href="https://developer.watsonwork.ibm.com/tools/graphql?apiType=beta" target="_blank" >apiType=beta on the graphical GraphQL tool URL</a>.
+
+
 Watson Work Services analyzes messages in each space to identify **moments**.
 
-Each moment includes a summary of a group of messages. The summary includes key phrases, participants, and other information extracted from messages.
+Each moment includes a summary of a group of messages. The summary includes summary phrases, participants, and other information extracted from messages.
 
 Observers can catch up and understand the significance of activity that has transpired since their last visit, or use moments to get a glimpse into an ongoing discussion without reading all the messages.
 
-Moments are automatically created as the chat in each space progresses. A moment is presented with this object.
+Moments are automatically created as the chat in each space progresses.
+
+The [Conversation](./guides/V1_conversation_main.md) object also references the collection of moments for that conversation, so in addition to dedicated queries for moments by their ID or by a space ID, you can query for moments in many places where you query for messages in conversations.
 
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
 | id | ID | The unique ID for this moment. The ID scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. |
 | live | Boolean | The status whether this moment is still under updating |
-| startTime | Date | Date this moment is started |
-| endTime | Date | Date this moment is ended |
-| keyMessage | Message | The message which is identified as the most representative one in this moment |
+| startTime | Date | Date and time this moment started |
+| endTime | Date | Date and time this moment ended |
+| keyMessage | Message | A messages which is most representative of the discussion in the moment |
 | summaryPhrases | [SummaryPhrase] | The key phrases of the summary for this moment |
 | participants | [Participant] | The participants of this moment |
-| priority | UserPriorityStatus | Conveys information about the priority of this moment for this user |
-| mentioned | [Mentioned] | Mentions in this moment |
-| messages | MessageCollection | Messages in this moment |
-| space | Space | The space where the moment is in |
+| mentioned | [Mentioned] | Mentions of people in this moment |
+| messages | MessageCollection | Filterable messages in this moment |
+| space | Space | The space where the moment occurred |
 
-### SummaryPhrase
-###### SummaryPhrase interface
+## SummaryPhrase
+### SummaryPhrase interface
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
 | label | String | The display string of this phrase |
-| score | Float | The confidence of this phrase |
+| score | Float | The confidence of this phrase, if applicable |
 
-###### Keyword (implements SummaryPhrase)
+### Keyword (implements SummaryPhrase)
 
-###### Entity (implements SummaryPhrase)
+The keyword interface is used to distinguish a keyword summary phrase, but currently adds no unique properties of its own.
+
+### Entity (implements SummaryPhrase)
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
 | count | Int | The count of this entity phrase in the moment |
 
 
-### Participant
+## Participant
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
-| user | Person | The user info of this participant |
+| user | Person | The user information of this participant |
 | messageCount | Int | The total message count of this participant in this moment |
 | viaAppUsers | AppUser | The extra user info from App participant, should be null for normal user |
 
-###### AppUser
+### AppUser
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
 | displayName | String | The display name of this 3rd party App user |
 | photoUrl | String | The photo url of this App user |
 | url | String | The url of this App user |
-
-
-### UserPriorityStatus
-| property      | type          | description  |
-| ------------- |:------------- |:-----|
-| predicted | Boolean | Whether this moment is a priority. The predicted field may be null if a prediction is not yet available. |
-| support | [SupportingFeature] | Features which support the prediction made in this UserPriorityStatus. If a priority is predicted, each SupportingFeature is a personalized reason the system predicted the moment as a priority for the current user. If a priority is not predicted, each SupportingFeature is a personalized reason the system predicted the moment was not a priority. The SupportingFeatures may be null if not enough is known about the user to make a prediction. |
-
-###### SupportingFeature
-An abstract representation of something which supports a priority prediction. Implementing classes represent specific types of features.
-
-| property      | type          | description  |
-| ------------- |:------------- |:-----|
-| category | PriorityFeatureType | The category of the support |
-
-###### PriorityFeatureType
-An enum of the category of the support.
-
-| value | description |
-|:------|:------ |
-| USER_MARK | category for SupportingUserMark |
-| PARTICIPANT | category for SupportingParticipant |
-| PHRASE | category for SupportingPhrase |
-
-###### SupportingUserMark (implements SupportingFeature)
-Indicates the user has explicitly marked the item as a priority.
-
-###### SupportingParticipant (implements SupportingFeature)
-References a person that was meaningful to the priority prediction.
-
-| property      | type          | description  |
-| ------------- |:------------- |:-----|
-| person | Person | The referenced person |
-
-###### SupportingPhrase (implements SupportingFeature)
-References a phrase that was meaningful to the priority prediction.
-
-| property      | type          | description  |
-| ------------- |:------------- |:-----|
-| label | String | The referenced phrase |

--- a/guides/V1_moment_main.md
+++ b/guides/V1_moment_main.md
@@ -61,10 +61,8 @@ The keyword interface is used to distinguish a keyword summary phrase, but curre
 
 ### AppUser
 
-If present, the AppUser represents information sent to Watson Work through the [actor fields when the message was created](./guides/V1_wwsg_Spaces.md).
+If present, the AppUser represents information sent to Watson Work through the [actor field when the message was created](./guides/V1_wwsg_Spaces.md).
 
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
 | displayName | String | The display name of this 3rd party App user |
-| photoUrl | String | The photo url of this App user |
-| url | String | The url of this App user |

--- a/guides/V1_moment_main.md
+++ b/guides/V1_moment_main.md
@@ -18,7 +18,7 @@ Each moment includes a summary of a group of messages. The summary includes summ
 
 Observers can catch up and understand the significance of activity that has transpired since their last visit, or use moments to get a glimpse into an ongoing discussion without reading all the messages.
 
-Moments are automatically created as the chat in each space progresses.
+Moments are automatically created as a conversation progresses.
 
 The [Conversation](./guides/V1_conversation_main.md) object also references the collection of moments for that conversation, so in addition to dedicated queries for moments by their ID or by a space ID, you can query for moments in many places where you query for messages in conversations.
 
@@ -60,6 +60,9 @@ The keyword interface is used to distinguish a keyword summary phrase, but curre
 | viaAppUsers | AppUser | The extra user info from App participant, should be null for normal user |
 
 ### AppUser
+
+If present, the AppUser represents information sent to Watson Work through the [actor fields when the message was created](./guides/V1_wwsg_Spaces.md).
+
 | property      | type          | description  |
 | ------------- |:------------- |:-----|
 | displayName | String | The display name of this 3rd party App user |


### PR DESCRIPTION
Added a main section for moments GraphQL documentation, including a table for the object types and 1 subpage for query.

We could add more examples here, but I'm inclined to write some doc on things like interfaces, variables and get some pagination doc visible in the navigation before I do that since those would be useful for more advanced queries, so wanted to get this in now and can add more examples later.