### PR TITLE
[Ready to Merge] Add more notes around the functionality of updateMessage

### DIFF
--- a/guides/V1_UpdateMessage.md
+++ b/guides/V1_UpdateMessage.md
@@ -17,7 +17,7 @@ Notes:
 
  - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as `message-annotation-added` events.
 
- - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but using the user's identity, an app will be allowed to update the user's messages as that user.
+ - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but when the app is running on behalf of a user, it will be allowed to update the user's messages as that user.
 
  - An app can not update a message created via generic annotation or by using generic annotations.
 

--- a/guides/V1_UpdateMessage.md
+++ b/guides/V1_UpdateMessage.md
@@ -11,15 +11,16 @@ is: 'experimental'
 The _updateMessage_ mutation allows the API caller to change the contents of a message.  The mutation accepts a message id (id) and the new content (content) as arguments, and makes the request on behalf of the caller, adding the specified new content to the message replacing the previous message content.
 
 Notes:
-<br>
+
+
  - Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a **403 Forbidden** response.
-<br>
- - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.
-<br>
- - Apps calling the updateMessage mutation using the app's identity will rejected with a **400 Bad Request** response, but using the user's identity, an app will be allowed to update the user's messages as that user.
-<br>
+
+ - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as message-annotation-added events.
+
+ - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but using the user's identity, an app will be allowed to update the user's messages as that user.
+
  - An app can not update a message created via generic annotation or by using generic annotations.
-<br><br>
+
 
 ## Schema
 

--- a/guides/V1_UpdateMessage.md
+++ b/guides/V1_UpdateMessage.md
@@ -17,7 +17,7 @@ Notes:
 
  - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as `message-annotation-added` events.
 
- - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but when the app is running on behalf of a user, it will be allowed to update the user's messages as that user.
+ - Apps calling the updateMessage mutation using the app's identity will be rejected with a **403 Forbidden** response, but when the app is running on behalf of a user, it will be allowed to update the user's messages as that user.
 
  - An app can not update a message created via generic annotation or by using generic annotations.
 

--- a/guides/V1_UpdateMessage.md
+++ b/guides/V1_UpdateMessage.md
@@ -9,7 +9,17 @@ is: 'experimental'
 ## Concepts
 
 The _updateMessage_ mutation allows the API caller to change the contents of a message.  The mutation accepts a message id (id) and the new content (content) as arguments, and makes the request on behalf of the caller, adding the specified new content to the message replacing the previous message content.
-Note: Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a 403 Forbidden response.
+
+Notes:
+<br>
+ - Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a **403 Forbidden** response.
+<br>
+ - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.
+<br>
+ - Apps calling the updateMessage mutation using the app's identity will rejected with a **400 Bad Request** response, but using the user's identity, an app will be allowed to update the user's messages as that user.
+<br>
+ - An app can not update a message created via generic annotation or by using generic annotations.
+<br><br>
 
 ## Schema
 

--- a/guides/V1_UpdateMessage.md
+++ b/guides/V1_UpdateMessage.md
@@ -15,7 +15,7 @@ Notes:
 
  - Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a **403 Forbidden** response.
 
- - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as message-annotation-added events.
+ - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as `message-annotation-added` events.
 
  - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but using the user's identity, an app will be allowed to update the user's messages as that user.
 

--- a/guides/V1_wwsg_EditingMessages.md
+++ b/guides/V1_wwsg_EditingMessages.md
@@ -16,7 +16,7 @@ Notes:
 
  - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as `message-annotation-added` events.
 
- - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but when the app is running on behalf of a user, it will be allowed to update the user's messages as that user.
+ - Apps calling the updateMessage mutation using the app's identity will be rejected with a **403 Forbidden** response, but when the app is running on behalf of a user, it will be allowed to update the user's messages as that user.
 
  - An app can not update a message created via generic annotation or by using generic annotations.
 

--- a/guides/V1_wwsg_EditingMessages.md
+++ b/guides/V1_wwsg_EditingMessages.md
@@ -9,10 +9,18 @@ Watson Work Services provides an **updateMessage** API for callers to change the
 
 ![Image](https://github.com/watsonwork/watsonwork-developer-docs/blob/master/images/editMessage.png)
 
-Note: Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a 403 Forbidden response.
-
+Notes:
+<br>
+ - Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a **403 Forbidden** response.
+<br>
+ - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.
+<br>
+ - Apps calling the updateMessage mutation using the app's identity will rejected with a **400 Bad Request** response, but using a user's identity, an app will be allowed to update the user's messages as that user.
+<br>
+ - An app can not update a message created via generic annotation or by using generic annotations.
+<br><br>
 ### External API
-
+<br><br>
  * GraphQL mutation for editing a message
     * **updateMessage** [Change the content of a message](https://github.com/watsonwork/watsonwork-developer-docs/blob/master/guides/V1_UpdateMessage.md)
     <br>

--- a/guides/V1_wwsg_EditingMessages.md
+++ b/guides/V1_wwsg_EditingMessages.md
@@ -16,7 +16,7 @@ Notes:
 
  - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as `message-annotation-added` events.
 
- - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but using a user's identity, an app will be allowed to update the user's messages as that user.
+ - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but when the app is running on behalf of a user, it will be allowed to update the user's messages as that user.
 
  - An app can not update a message created via generic annotation or by using generic annotations.
 

--- a/guides/V1_wwsg_EditingMessages.md
+++ b/guides/V1_wwsg_EditingMessages.md
@@ -14,7 +14,7 @@ Notes:
 
  - Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a **403 Forbidden** response.
 
- - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as message-annotation-added events.
+ - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as `message-annotation-added` events.
 
  - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but using a user's identity, an app will be allowed to update the user's messages as that user.
 

--- a/guides/V1_wwsg_EditingMessages.md
+++ b/guides/V1_wwsg_EditingMessages.md
@@ -10,22 +10,27 @@ Watson Work Services provides an **updateMessage** API for callers to change the
 ![Image](https://github.com/watsonwork/watsonwork-developer-docs/blob/master/images/editMessage.png)
 
 Notes:
-<br>
+
+
  - Only the author of a message can update its content.  Updating the content of messages not created by the calling user will receive a **403 Forbidden** response.
-<br>
- - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.
-<br>
- - Apps calling the updateMessage mutation using the app's identity will rejected with a **400 Bad Request** response, but using a user's identity, an app will be allowed to update the user's messages as that user.
-<br>
+
+ - Existing annotations will be stripped from an updated message.  Apps are expected to regenerate any annotation using the new content.  Mention annotations are automatically regenerated based on the new content.  These annotations will be sent as message-annotation-added events.
+
+ - Apps calling the updateMessage mutation using the app's identity will be rejected with a **400 Bad Request** response, but using a user's identity, an app will be allowed to update the user's messages as that user.
+
  - An app can not update a message created via generic annotation or by using generic annotations.
-<br><br>
+
+
+
 ### External API
-<br><br>
+
  * GraphQL mutation for editing a message
     * **updateMessage** [Change the content of a message](https://github.com/watsonwork/watsonwork-developer-docs/blob/master/guides/V1_UpdateMessage.md)
-    <br>
+    
+    
  * Outbound webhooks [Event for edited message](https://github.com/watsonwork/watsonwork-developer-docs/blob/master/guides/V1_wwsg_Webhooks.md)
     * **message-edited**
-<br><br>
+
+
 
 


### PR DESCRIPTION
Add more notes around the functionality of updateMessage to reflect/explain what happens to the various aspects of the message when it gets updated? Specifically:

 - What happens to existing annotations?
 - What happens when an app tries to call this mutation using app as identity vs user?
 - Can an app update a message that it created via generic annotation?