### PR TITLE
Correct release flag for reactions

### DIFF
--- a/guides/V1_Add_Reaction.md
+++ b/guides/V1_Add_Reaction.md
@@ -1,7 +1,7 @@
 ---
 copyright: 'Copyright IBM Corp. 2018'
 link: 'add-a-reaction'
-is: 'experimental'
+is: 'published'
 ---
 
 # Add a Reaction
@@ -43,7 +43,7 @@ type AddReactionInput {
 ~~~~
 Method: POST
 URL: https://api.watsonwork.ibm.com/graphql
-Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC, EXPERIMENTAL'
+Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC'
 Body:
 {
   mutation {

--- a/guides/V1_Reacting_Users.md
+++ b/guides/V1_Reacting_Users.md
@@ -1,7 +1,7 @@
 ---
 copyright: 'Copyright IBM Corp. 2018'
 link: 'reacting-users'
-is: 'experimental'
+is: 'published'
 ---
 
 # Query for Users Reacting to a Message
@@ -40,7 +40,7 @@ type ReactingUserCollection {
 ~~~~
 Method: POST
 URL: https://api.watsonwork.ibm.com/graphql
-Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC, EXPERIMENTAL'
+Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC'
 Body:
 {
   query {

--- a/guides/V1_Remove_Reaction.md
+++ b/guides/V1_Remove_Reaction.md
@@ -1,7 +1,7 @@
 ---
 copyright: 'Copyright IBM Corp. 2018'
 link: 'remove-a-reaction'
-is: 'experimental'
+is: 'published'
 ---
 
 # Remove a Reaction
@@ -43,7 +43,7 @@ type RemoveReactionInput {
 ~~~~
 Method: POST
 URL: https://api.watsonwork.ibm.com/graphql
-Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC, EXPERIMENTAL'
+Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC'
 Body:
 {
   mutation {

--- a/guides/V1_delete_message.md
+++ b/guides/V1_delete_message.md
@@ -36,7 +36,7 @@ type DeleteMessageInput {
 ~~~~
 Method: POST
 URL: https://api.watsonwork.ibm.com/graphql
-Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC, EXPERIMENTAL'
+Headers: 'Content-Type: application/graphql' , 'x-graphql-view: PUBLIC'
 Body:
 {
   mutation {

--- a/guides/V1_wwsg_Reactions.md
+++ b/guides/V1_wwsg_Reactions.md
@@ -1,7 +1,7 @@
 ---
 copyright: 'Copyright IBM Corp. 2018'
 link: 'reactions-overview'
-is: 'experimental'
+is: 'published'
 ---
 ## Reactions Overview
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "watsonwork-developer-docs",
-  "version": "1.0.0",
-  "lockfileVersion": 1
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "watsonwork-developer-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
This PR corrects the release flag for `reactions`, which has been released publicly, but is marked as `experimental` in some places in the document.