### PR TITLE
Add conversationId and conversationType to message fields

### DIFF
--- a/references/V1_OutboundCallback.md
+++ b/references/V1_OutboundCallback.md
@@ -362,7 +362,7 @@ This event is only sent to webhooks that
 
 <a name="conversationupdatedbody"></a>
 ### ConversationUpdatedBody
-Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
+Notifies the update of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
 
 This event is only sent to webhooks that
 - have been added for the conversation-updated event.
@@ -370,7 +370,7 @@ This event is only sent to webhooks that
 
 <a name="conversationdeletedbody"></a>
 ### ConversationDeletedBody
-Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
+Notifies the deletion of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
 
 This event is only sent to webhooks that
 - have been added for the conversation-deleted event.

--- a/references/V1_OutboundCallback.md
+++ b/references/V1_OutboundCallback.md
@@ -353,7 +353,7 @@ This event is only sent to webhooks that
 - and belong to an app that is a member of the space.
 
 <a name="conversationcreatedbody"></a>
-### ConversationCreatedByody
+### ConversationCreatedBody
 Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
 
 This event is only sent to webhooks that
@@ -361,7 +361,7 @@ This event is only sent to webhooks that
 - and belong to an app that is a member of the space.
 
 <a name="conversationupdatedbody"></a>
-### ConversationUpdatedByody
+### ConversationUpdatedBody
 Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
 
 This event is only sent to webhooks that
@@ -369,7 +369,7 @@ This event is only sent to webhooks that
 - and belong to an app that is a member of the space.
 
 <a name="conversationdeletedbody"></a>
-### ConversationDeletedByody
+### ConversationDeletedBody
 Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
 
 This event is only sent to webhooks that

--- a/references/V1_OutboundCallback.md
+++ b/references/V1_OutboundCallback.md
@@ -5,7 +5,7 @@
 ## Overview
 This API has to be implemented by the callbacks implementing outbound webhooks.
 
-- Changes in versiaon 1.8.0:
+- Changes in version 1.8.0:
   - New feilds conversationId and conversationType added to `message-created`, `message-deleted` and `message-edited`.
 - Changes in version 1.7.0:
   - New event type and notification format for `message-edited`.
@@ -26,7 +26,7 @@ This API has to be implemented by the callbacks implementing outbound webhooks.
 
 
 ### Version information
-*Version* : 1.2.0
+*Version* : 1.8.0
 
 
 ### URI scheme
@@ -352,6 +352,29 @@ This event is only sent to webhooks that
 - have been added for the reaction-removed event
 - and belong to an app that is a member of the space.
 
+<a name="conversationcreatedbody"></a>
+### ConversationCreatedByody
+Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
+
+This event is only sent to webhooks that
+- have been added for the conversation-created event.
+- and belong to an app that is a member of the space.
+
+<a name="conversationupdatedbody"></a>
+### ConversationUpdatedByody
+Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
+
+This event is only sent to webhooks that
+- have been added for the conversation-updated event.
+- and belong to an app that is a member of the space.
+
+<a name="conversationdeletedbody"></a>
+### ConversationDeletedByody
+Notifies the creation of a conversation. _Since this is an_ `EXPERIMENTAL` _capability, complete information can be found in our github repo, [see Coming Next section](../get-started/coming-next) for more info_.
+
+This event is only sent to webhooks that
+- have been added for the conversation-deleted event.
+- and belong to an app that is a member of the space.
 
 
 

--- a/references/V1_OutboundCallback.md
+++ b/references/V1_OutboundCallback.md
@@ -5,6 +5,8 @@
 ## Overview
 This API has to be implemented by the callbacks implementing outbound webhooks.
 
+- Changes in versiaon 1.8.0:
+  - New feilds conversationId and conversationType added to `message-created`, `message-deleted` and `message-edited`.
 - Changes in version 1.7.0:
   - New event type and notification format for `message-edited`.
 - Changes in version 1.6.0:
@@ -189,6 +191,8 @@ This event is only sent to webhooks that
 |**messageId**  <br>*required*|Unique id of the message.|string|
 |**spaceId**  <br>*required*|Id of the space in which the message was created.|string|
 |**spaceName**  <br>*required*|Name of the space in which the message was created.|string|
+|**conversationId** <br>*required*|Id of the conversation in which the message was created.|string|
+|**conversationType** <br>*required*|Type of conversation in which the message was created.|string|
 |**time**  <br>*required*|Time and date of message creation, in milliseconds since January 1st, 00:00, 1970 UTC|integer(int64)|
 |**type**  <br>*required*|The event type is `message-created`.|string|
 |**userId**  <br>*required*|Id of the user who created the message.|string|
@@ -208,6 +212,8 @@ This event is only sent to webhooks that
 |---|---|---|
 |**messageId**  <br>*required*|Unique id of the message.|string|
 |**spaceId**  <br>*required*|Id of the space in which the message was deleted.|string|
+|**conversationId** <br>*required*|Id of the conversation in which the message was deleted.|string|
+|**conversationType** <br>*required*|Type of conversation in which the message was deleted.|string|
 |**time**  <br>*required*|Time and date of message deletion, in milliseconds since January 1st, 00:00, 1970 UTC|integer(int64)|
 |**type**  <br>*required*|The event type is `message-deleted`.|string|
 
@@ -227,6 +233,8 @@ This event is only sent to webhooks that
 |**contentType**  <br>*required*|Mime type of the message content.|string|
 |**messageId**  <br>*required*|Unique id of the message.|string|
 |**spaceId**  <br>*required*|Id of the space in which the message was edited.|string|
+|**conversationId** <br>*required*|Id of the conversation in which the message was edited.|string|
+|**converstaionType** <br>*reqired*|Type of the conversation in which the message was edited.|string|
 |**time**  <br>*required*|Time and date of message edit, in milliseconds since January 1st, 00:00, 1970 UTC|integer(int64)|
 |**type**  <br>*required*|The event type is `message-edited`.|string|
 |**userId**  <br>*required*|Id of the user who edited the message.|string|

--- a/references/V1_OutboundCallback.yml
+++ b/references/V1_OutboundCallback.yml
@@ -5,7 +5,7 @@ info:
   description: |
     This API has to be implemented by the callbacks implementing outbound webhooks.
 
-    - Changes in versaion 1.8.0:
+    - Changes in version 1.8.0:
       - New feilds conversationId and conversationType added to `message-created`, `message-deleted` and `message-edited`.
 -     Changes in version 1.7.0:
       - New event type and notification format for `message-edited`.
@@ -23,7 +23,7 @@ info:
     - Changes in version 1.1.0:
       - The verification process of outbound webhooks has changed.
       - The `GET` endpoint has been removed.  The `POST` endpoint is now used for the verification of outbound webhooks.
-  version: 1.2.0
+  version: 1.8.0
 host: api.watsonwork.ibm.com
 schemes:
   - https

--- a/references/V1_OutboundCallback.yml
+++ b/references/V1_OutboundCallback.yml
@@ -5,6 +5,8 @@ info:
   description: |
     This API has to be implemented by the callbacks implementing outbound webhooks.
 
+    - Changes in versaion 1.8.0:
+      - New feilds conversationId and conversationType added to `message-created`, `message-deleted` and `message-edited`.
 -     Changes in version 1.7.0:
       - New event type and notification format for `message-edited`.
     - Changes in version 1.6.0:
@@ -93,6 +95,12 @@ definitions:
       spaceName:
         description: Name of the space in which the message was created.
         type: string
+      conversationId:
+        description: Id of the conversation in which the message was created.
+        type: string
+      conversationType:
+        description: Type of conversation in which the message was created.
+        type: string
       messageId:
         description: Unique id of the message.
         type: string
@@ -112,6 +120,8 @@ definitions:
       - userName
       - spaceId
       - spaceName
+      - conversationId
+      - conversationType
       - messageId
       - content
       - contentType
@@ -131,6 +141,12 @@ definitions:
       spaceId:
         description: Id of the space in which the message was deleted.
         type: string
+      conversationId:
+        description: Id of the conversation in which the message was deleted.
+        type: string
+      conversationType:
+        description: Type of conversation in which the message was deleted.
+        type: string
       messageId:
         description: Unique id of the message.
         type: string
@@ -141,6 +157,8 @@ definitions:
     required:
       - type
       - spaceId
+      - conversationId
+      - conversationType
       - messageId
       - time
   SpaceMembersAddedBody:
@@ -195,6 +213,12 @@ definitions:
       spaceId:
         description: Id of the space in which the message was edited.
         type: string
+      conversationId:
+        description: Id of the conversation in which the message was edited.
+        type: string
+      conversationType:
+        description: Type of conversation in which the message was edited.
+        type: string
       messageId:
         description: Unique id of the message.
         type: string
@@ -212,6 +236,8 @@ definitions:
       - type
       - userId
       - spaceId
+      - conversationId
+      - conversationType
       - messageId
       - content
       - contentType


### PR DESCRIPTION
Update Outbound Webhooks doc to include `conversationId` and `conversationType` to the proper fields.